### PR TITLE
Some additional request keys + custom HTTP clients

### DIFF
--- a/src/circleci/rollcage/http.clj
+++ b/src/circleci/rollcage/http.clj
@@ -1,0 +1,16 @@
+(ns circleci.rollcage.http
+  (:require [clj-http.client :as http]))
+
+(defprotocol HttpClient
+  (post [this url json]
+    "Makes a post request to Rollbar API and returns response body"))
+
+(defrecord CljHttpClient []
+  HttpClient
+  (post [this url json]
+    (-> (http/post url {:body json :content-type :json}) :body)))
+
+(defn make-default-http-client
+  "Makes clj-http client"
+  []
+  (->CljHttpClient))


### PR DESCRIPTION
Hi,

First of all, thanks for the library.

I added some additional API request keys / features I needed for my projects (all changes are backwards-compatible):
- ability to pass request, person, framework and context keys to the Items API
- ability to use a different HTTP Client (for example, someone might want to use persistent connections etc.)
- slightly refactored code responsible for request parameters building, because it became too verbose after adding extra keys.

Hope it's okay!
