### PR TITLE
Uncaught exception handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ user=> (try
 {:err 0, :result {:id nil, :uuid "1cb0c8bf-3942-4553-a5c4-8adc5d55ed8f"}}
 ```
 
+You can also setup handler for all UncaughtExceptions.
+Call this fn during start-up procedure to ensure all uncaught exceptions
+will be sent to Rollbar.
+
+user=> (rollcage/setup-uncaught-exception-handler r)
+
+
 ## Testing
 
 A full CI suite is [run on CircleCI](https://circleci.com/gh/circleci/rollcage).

--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -164,6 +164,24 @@
    (send-item endpoint
               (make-rollbar client level exception url params))))
 
+
+(defn report-uncaught-exception
+  [level client exception thread]
+  (let [custom-data {:thread (.getName thread)}]
+    (send-item endpoint
+               (make-rollbar client level exception nil custom-data))))
+
+(defn setup-uncaught-exception-handler
+  "Setup handler to report all uncaught exceptions
+   to rollbar."
+  ([client]
+   (setup-uncaught-exception-handler client "error"))
+  ([client level]
+   (Thread/setDefaultUncaughtExceptionHandler
+     (reify Thread$UncaughtExceptionHandler
+       (uncaughtException [_ thread ex]
+         (report-uncaught-exception level client ex thread))))))
+
 (def critical (partial notify "critical"))
 (def error    (partial notify "error"))
 (def warning  (partial notify "warning"))


### PR DESCRIPTION
Since in JVM thread can die silently we often setup uncaughtException handler during our startup procedure.

Once we moved to rollbar for error reporting (thanks for this lib btw) we d like to have those reported as well. 

Added setup-uncaught-exception-handler ensures all uncaught exceptions are reported using rollcage client.
