### PR TITLE
Fix environment for lein release

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,4 +20,7 @@ deployment:
   clojars:
     branch: master
     commands:
+      - git clean -d --force
+      - git config --global user.email "sayhi@circleci.com"
+      - git config --global user.name "CircleCI builder"
       - lein release :patch


### PR DESCRIPTION
This should allow `lein release` to proceed.

NOTE: This patch in and of itself will not fix releases, the build won't be able to push commits upstream without additional project settings on circleci.com to allow that. 