### PR TITLE
Add ability to specify reporting fn for uncaught exs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,10 +3,10 @@
   :url "http://github.com/circleci/rollcage"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :deploy-repositories ^:replace [["clojars" {:url "https://clojars.org/repo"
-                                              :username [:gpg :env/clojars_username]
-                                              :password [:gpg :env/clojars_password]
-                                              :sign-releases false}]]
+  :deploy-repositories ^:replace [["releases" {:url "https://clojars.org/repo"
+                                               :username [:gpg :env/clojars_username]
+                                               :password [:gpg :env/clojars_password]
+                                               :sign-releases false}]]
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [cheshire "5.4.0"]
                  [clj-http "2.0.0"]

--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -175,12 +175,14 @@
   "Setup handler to report all uncaught exceptions
    to rollbar."
   ([client]
-   (setup-uncaught-exception-handler client "error"))
+   (setup-uncaught-exception-handler client "error" report-uncaught-exception))
   ([client level]
+   (setup-uncaught-exception-handler client level report-uncaught-exception))
+  ([client level reporting-fn]
    (Thread/setDefaultUncaughtExceptionHandler
      (reify Thread$UncaughtExceptionHandler
        (uncaughtException [_ thread ex]
-         (report-uncaught-exception level client ex thread))))))
+         (reporting-fn level client ex thread))))))
 
 (def critical (partial notify "critical"))
 (def error    (partial notify "error"))


### PR DESCRIPTION
Custom reporting function will allow having more control over uncaught exceptions. For instance, log them. 