### PR TITLE
Add utility functions to rollcage

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,6 @@
                                               :password [:gpg :env/clojars_password]
                                               :sign-releases false}]]
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/tools.logging "0.3.1"]
                  [cheshire "5.4.0"]
                  [clj-http "2.0.0"]
                  [prismatic/schema "0.4.3"]

--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
                                               :password [:gpg :env/clojars_password]
                                               :sign-releases false}]]
   :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/tools.logging "0.3.1"]
                  [cheshire "5.4.0"]
                  [clj-http "2.0.0"]
                  [prismatic/schema "0.4.3"]

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
             [lein-pprint "1.1.1"]
             [lein-test-out "0.3.1" :exclusions [org.clojure/clojure]]]
   :profiles {:dev {:dependencies [[org.clojure/test.check "0.7.0"]
-                                  [bond "0.2.5"]]}}
+                                  [circleci/bond "0.2.9"]]}}
   :test-selectors {:all         (constantly true)
                    :default     (constantly true)
                    :unit        (complement :integration)

--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -198,12 +198,3 @@
 (def warning  (partial notify "warning"))
 (def info     (partial notify "info"))
 (def debug    (partial notify "debug"))
-
-(defn configure-rollbar!
-  "Make rollcage handle uncaught exceptions and return a rollcage client."
-  [rollbar-token environment]
-  (when-not (string/blank? rollbar-token)
-    (infof "configuring rollbar, environment=%s" environment)
-    (let [client (client rollbar-token {:environment environment})]
-      (setup-uncaught-exception-handler client)
-      client)))

--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -1,7 +1,6 @@
 (ns circleci.rollcage.core
   (:require
     [clojure.string :as string]
-    [clojure.tools.logging :refer (infof errorf)]
     [cheshire.core :as json]
     [schema.core :as s]
     [clj-http.client :refer (post)]
@@ -199,18 +198,6 @@
 (def warning  (partial notify "warning"))
 (def info     (partial notify "info"))
 (def debug    (partial notify "debug"))
-
-(defn rollbar-reporter
-  "Returns a rollbar reporter function that takes an exception and
-  reports it to rollbar with the given params."
-  [rollcage-client params]
-  (infof "rollbar reporting configured for %s" params)
-  (fn [^Throwable ex]
-    (try
-      (error rollcage-client ex {:params params})
-      (catch Exception e
-        (errorf e "Unable to report exception to rollbar, original exception follows")
-        (.printStackTrace ex)))))
 
 (defn configure-rollbar!
   "Make rollcage handle uncaught exceptions and return a rollcage client."

--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -1,6 +1,7 @@
 (ns circleci.rollcage.core
   (:require
     [clojure.string :as string]
+    [clojure.tools.logging :refer (infof errorf)]
     [cheshire.core :as json]
     [schema.core :as s]
     [clj-http.client :refer (post)]
@@ -187,3 +188,12 @@
 (def warning  (partial notify "warning"))
 (def info     (partial notify "info"))
 (def debug    (partial notify "debug"))
+
+(defn configure-rollbar!
+  "Make rollcage handle uncaught exceptions and return a rollcage client."
+  [rollbar-token environment]
+  (when-not (string/blank? rollbar-token)
+    (infof "configuring rollbar, environment=%s" environment)
+    (let [client (client rollbar-token {:environment environment})]
+      (setup-uncaught-exception-handler client)
+      client)))

--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -189,6 +189,18 @@
 (def info     (partial notify "info"))
 (def debug    (partial notify "debug"))
 
+(defn rollbar-reporter
+  "Returns a rollbar reporter function that takes an exception and
+  reports it to rollbar with the given params."
+  [rollcage-client params]
+  (infof "rollbar reporting configured for %s" params)
+  (fn [^Throwable ex]
+    (try
+      (error rollcage-client ex {:params params})
+      (catch Exception e
+        (errorf e "Unable to report exception to rollbar, original exception follows")
+        (.printStackTrace ex)))))
+
 (defn configure-rollbar!
   "Make rollcage handle uncaught exceptions and return a rollcage client."
   [rollbar-token environment]

--- a/src/circleci/rollcage/ring_middleware.clj
+++ b/src/circleci/rollcage/ring_middleware.clj
@@ -1,0 +1,12 @@
+(ns circleci.rollcage.ring-middleware
+  (:require [circleci.rollcage.core :as rollcage]))
+
+(defn wrap-rollbar [handler rollcage-client]
+  (if-not rollcage-client
+    handler
+    (fn [req]
+      (try
+        (handler req)
+        (catch Exception e
+          (rollcage/error rollcage-client e (select-keys req [:uri]))
+          (throw e))))))

--- a/test/circleci/rollcage/test_core.clj
+++ b/test/circleci/rollcage/test_core.clj
@@ -6,7 +6,6 @@
             [clojure.string :as string]
             [circleci.rollcage.core :as client]
             [clj-http.client :as http-client]
-            [clojure.tools.logging :as logging]
             [clojure.test.check.clojure-test :as ct :refer (defspec)]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop])
@@ -163,21 +162,3 @@
           thread (Thread. "thread")
           {:keys [err]} (client/report-uncaught-exception "error" c e thread)]
       (is (zero? err)))))
-
-(deftest rollbar-reporter-works
-  (let [dummy-rollcage-client {}
-        dummy-params {:some-params :some-values}
-        dummy-error (ex-info "something bad happened" {})
-        reporter (client/rollbar-reporter dummy-rollcage-client
-                                           dummy-params)]
-    (testing "passes exception to rollcage"
-      (bond/with-stub [client/error]
-        (reporter dummy-error)
-        (is ([[dummy-rollcage-client dummy-error {:params dummy-params}]]
-             (->> client/error bond/calls (map :args))))))
-    (testing "logs stacktrace when rollcage throws"
-      (bond/with-stub [[client/error (fn [_ _ _]
-                                         (throw (ex-info "some error" {})))]
-                       logging/log*]
-        (reporter dummy-error)
-        (is (1 (->> logging/log* bond/calls count)))))))

--- a/test/circleci/rollcage/test_ring_middleware.clj
+++ b/test/circleci/rollcage/test_ring_middleware.clj
@@ -1,0 +1,21 @@
+(ns circleci.rollcage.test-ring-middleware
+  (:require [bond.james :as bond]
+            [circleci.rollcage.ring-middleware :as middleware]
+            [circleci.rollcage.core :as rollcage]
+            [clojure.test :refer (deftest)]))
+
+(deftest wrap-rollbar-works
+  (let [dummy-ring-handler (fn [_]
+                             (throw (ex-info "something bad happened" {})))
+        dummy-rollcage-client {}
+        dummy-request {:uri "/" :params {}}
+        wrapped-handler (middleware/wrap-rollbar dummy-ring-handler
+                                                 dummy-rollcage-client)]
+    (bond/with-stub [rollcage/error]
+      (try
+        (wrapped-handler dummy-request)
+        (catch Exception e
+          (is (= [[dummy-rollcage-client e {:uri "/"}]]
+                 (->> rollcage/error
+                      bond/calls
+                      (map :args)))))))))

--- a/test/circleci/rollcage/test_ring_middleware.clj
+++ b/test/circleci/rollcage/test_ring_middleware.clj
@@ -2,20 +2,36 @@
   (:require [bond.james :as bond]
             [circleci.rollcage.ring-middleware :as middleware]
             [circleci.rollcage.core :as rollcage]
-            [clojure.test :refer (deftest is)]))
+            [clojure.test :refer (deftest is testing)]))
 
 (deftest wrap-rollbar-works
-  (let [dummy-ring-handler (fn [_]
-                             (throw (ex-info "something bad happened" {})))
-        dummy-rollcage-client {}
-        dummy-request {:uri "/" :params {}}
-        wrapped-handler (middleware/wrap-rollbar dummy-ring-handler
-                                                 dummy-rollcage-client)]
-    (bond/with-stub [rollcage/error]
-      (try
-        (wrapped-handler dummy-request)
-        (catch Exception e
-          (is (= [[dummy-rollcage-client e {:uri "/"}]]
-                 (->> rollcage/error
-                      bond/calls
-                      (map :args)))))))))
+  (let [error (ex-info "something bad happened" {})
+        dummy-ring-handler (fn [_]
+                             (throw error)
+                             {:status 200})
+        dummy-request {:uri "/" :params {}}]
+    (testing "Reports rollbars when rollcage-client is truthy"
+      (let [dummy-rollcage-client {}
+            wrapped-handler (middleware/wrap-rollbar dummy-ring-handler
+                                                     dummy-rollcage-client)]
+        (bond/with-stub [rollcage/error]
+          (let [result (try
+                         (wrapped-handler dummy-request)
+                         (catch Exception e
+                           e))]
+            (is (= result error))
+            (is (= [[dummy-rollcage-client error {:uri "/"}]]
+                   (->> rollcage/error
+                        bond/calls
+                        (map :args))))))))
+    (testing "Doesn't report rollbars when rollcage-client is `nil`"
+      (let [dummy-rollcage-client nil
+            wrapped-handler (middleware/wrap-rollbar dummy-ring-handler
+                                                     dummy-rollcage-client)]
+        (bond/with-stub [rollcage/error]
+          (let [result (try
+                         (wrapped-handler dummy-request)
+                         (catch Exception e
+                           e))]
+            (is (= result error))
+            (is (= 0 (-> rollcage/error bond/calls count)))))))))

--- a/test/circleci/rollcage/test_ring_middleware.clj
+++ b/test/circleci/rollcage/test_ring_middleware.clj
@@ -2,7 +2,7 @@
   (:require [bond.james :as bond]
             [circleci.rollcage.ring-middleware :as middleware]
             [circleci.rollcage.core :as rollcage]
-            [clojure.test :refer (deftest)]))
+            [clojure.test :refer (deftest is)]))
 
 (deftest wrap-rollbar-works
   (let [dummy-ring-handler (fn [_]


### PR DESCRIPTION
This PR adds three functions that consumers of the rollcage library would likely need to implement themselves: 

- ring middleware for handling uncaught exceptions thrown from ring handlers
- a function that returns a configured reporter that reports exceptions to rollbar
- a configuration function that creates a rollbar client and sets up rollcage as the default uncaught exception handler