### PR TITLE
Make sending and logging safer

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,9 +10,6 @@ machine:
 general:
   artifacts:
     - target/coverage
-dependencies:
-  pre:
-    - yes | sudo LEIN_ROOT=true lein upgrade
 test:
   pre:
     - mkdir $CIRCLE_TEST_REPORTS/lein

--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -138,14 +138,13 @@
    "info"     :info})
 
 (defn- send-item-null
-  [^String endpoint ^Throwable exception item]
-  (logging/log (rollbar-to-logging (get-in item [:data :level]))
+  [^String endpoint ^Throwable exception {:keys [data] :as item}]
+  (logging/log (rollbar-to-logging (:level data))
                exception
                "No Rollbar token configured. Not reporting exception.")
   {:err 0
-   :result {:uuid (-> item
-                      (get-in [:data :uuid])
-                      (str))}})
+   :skipped true
+   :result {:uuid (str (:uuid data))}})
 
 (defn- send-item-http
   "Send a Rollbar item using the HTTP REST API.

--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -13,7 +13,7 @@
 
 (def ^:private endpoint "https://api.rollbar.com/api/1/item/")
 
-(def ^:private Client {:access-token String
+(def ^:private Client {:access-token (s/maybe String)
                        :result-fn clojure.lang.IFn
                        :send-fn clojure.lang.IFn
                        :data {:environment (s/maybe String)
@@ -143,7 +143,9 @@
                exception
                "No Rollbar token configured. Not reporting exception.")
   {:err 0
-   :message "Rollbar is not configured. Item was not sent"})
+   :result {:uuid (-> item
+                      (get-in [:data :uuid])
+                      (str))}})
 
 (defn- send-item-http
   "Send a Rollbar item using the HTTP REST API.
@@ -158,7 +160,7 @@
     (json/parse-string (:body result) true)))
 
 (s/defn ^:private client* :- Client
-  [access-token :- String
+  [access-token :- (s/maybe String)
    {:keys [os hostname environment code-version file-root result-fn]
     :or {environment "production"}}]
   (let [os        (or os (guess-os))

--- a/test/circleci/rollcage/test_core.clj
+++ b/test/circleci/rollcage/test_core.clj
@@ -179,9 +179,9 @@
 
 (deftest report-uncaught-exception-test
   (let [p (promise)]
-    (with-redefs [client/send-item
-                  (fn [_ _ r _]
-                    (deliver p r)
+    (with-redefs [client/send-item-http
+                  (fn [_ _ item]
+                    (deliver p item)
                     {:err 0})]
       (let [c (client/client "access-token" {})
             e (Exception. "uncaught")

--- a/test/circleci/rollcage/test_core.clj
+++ b/test/circleci/rollcage/test_core.clj
@@ -139,9 +139,8 @@
         (is (UUID/fromString uuid))
         (is (realized? p))
         (is (= [e {:err 0
-                   :result {:id nil, :uuid uuid}}
- 
-                   ] @p))))))
+                   :result {:id nil, :uuid uuid}}]
+               @p))))))
 
 (deftest ^:integration it-can-send-items
   (let [token (System/getenv "ROLLBAR_ACCESS_TOKEN")
@@ -178,22 +177,29 @@
         (is (UUID/fromString uuid))))))
 
 (deftest report-uncaught-exception-test
-  (let [p (promise)]
-    (with-redefs [client/send-item-http
-                  (fn [_ _ item]
-                    (deliver p item)
-                    {:err 0})]
-      (let [c (client/client "access-token" {})
-            e (Exception. "uncaught")
-            thread (Thread. "thread")
-            {:keys [err]} (#'client/report-uncaught-exception "critical" c e thread)
-            result (deref p 0 :failed)]
-        (is (zero? err))
-        (is (not (= result :failed)))
-        (is (= "critical" (get-in result [:data :level])) )
-        (is (= "thread" (get-in result [:data :custom :thread-name])))
+  (let [p (promise)
+        c (assoc (client/client "access-token" {})
+                 :send-fn (fn [_ _ item]
+                            (deliver p item)
+                            {:err 0}))
+        e (Exception. "uncaught")
+        thread (Thread. "thread")
+        {:keys [err]} (#'client/report-uncaught-exception "critical" c e thread)
+        result (deref p 0 :failed)]
+    (is (zero? err))
+    (is (not (= result :failed)))
+    (is (= "critical" (get-in result [:data :level])) )
+    (is (= "thread" (get-in result [:data :custom :thread-name])))))
 
-        ))))
+(deftest it-handles-no-access-token
+  (let [token nil
+        cause (Exception. "connection error")
+        e (ex-info "system error" {:key1 "one" :key2 "two"} cause)]
+    (testing "it can send items"
+      (let [r (client/client token {:code-version "9d95d17105b4e752c46ccf656aaefad5ace50699"})
+            {err :err {uuid :uuid} :result} (client/warning r e)]
+        (is (zero? err))
+        (is (UUID/fromString uuid))))))
 
 (comment
   (run-tests))

--- a/test/circleci/rollcage/test_core.clj
+++ b/test/circleci/rollcage/test_core.clj
@@ -197,8 +197,9 @@
         e (ex-info "system error" {:key1 "one" :key2 "two"} cause)]
     (testing "it can send items"
       (let [r (client/client token {:code-version "9d95d17105b4e752c46ccf656aaefad5ace50699"})
-            {err :err {uuid :uuid} :result} (client/warning r e)]
+            {err :err skipped :skipped {uuid :uuid} :result} (client/warning r e)]
         (is (zero? err))
+        (is (true? skipped))
         (is (UUID/fromString uuid))))))
 
 (comment

--- a/test/circleci/rollcage/test_core.clj
+++ b/test/circleci/rollcage/test_core.clj
@@ -196,7 +196,8 @@
         cause (Exception. "connection error")
         e (ex-info "system error" {:key1 "one" :key2 "two"} cause)]
     (testing "it can send items"
-      (let [r (client/client token {:code-version "9d95d17105b4e752c46ccf656aaefad5ace50699"})
+      (let [r (client/client token {:file-root "/usr/local/src"
+                                    :code-version "9d95d17105b4e752c46ccf656aaefad5ace50699"})
             {err :err skipped :skipped {uuid :uuid} :result} (client/warning r e)]
         (is (zero? err))
         (is (true? skipped))


### PR DESCRIPTION
- Inject a send-fn that is used to send items, rather than changing
behaviour based on the presence or absense of a token.
- Enclose more of the sending process in a try/catch.
- Move logging deeper into the callstack.