### PR TITLE
Properly report ring request parameters

### DIFF
--- a/src/circleci/rollcage/ring_middleware.clj
+++ b/src/circleci/rollcage/ring_middleware.clj
@@ -8,5 +8,6 @@
       (try
         (handler req)
         (catch Exception e
-          (rollcage/error rollcage-client e (select-keys req [:uri]))
+          (rollcage/error rollcage-client e {:url (:uri req)
+                                             :params (dissoc req :uri)})
           (throw e))))))

--- a/src/circleci/rollcage/ring_middleware.clj
+++ b/src/circleci/rollcage/ring_middleware.clj
@@ -1,6 +1,10 @@
 (ns circleci.rollcage.ring-middleware
   (:require [circleci.rollcage.core :as rollcage]))
 
+(def ^:const request-and-wrap-parameter-keys
+  "selector for keys provided by ring's request map and by ring's wrap-parameter middleware"
+  [:http-method :query-string :query-params :form-params :params])
+
 (defn wrap-rollbar [handler rollcage-client]
   (if-not rollcage-client
     handler
@@ -9,5 +13,5 @@
         (handler req)
         (catch Exception e
           (rollcage/error rollcage-client e {:url (:uri req)
-                                             :params (dissoc req :uri)})
+                                             :params (select-keys req request-and-wrap-parameter-keys)})
           (throw e))))))

--- a/test/circleci/rollcage/test_ring_middleware.clj
+++ b/test/circleci/rollcage/test_ring_middleware.clj
@@ -9,7 +9,9 @@
         dummy-ring-handler (fn [_]
                              (throw error)
                              {:status 200})
-        dummy-request {:uri "/" :params {}}]
+        dummy-request {:http-method :get
+                       :uri "/search"
+                       :query-string "q=clojure"}]
     (testing "Reports rollbars when rollcage-client is truthy"
       (let [dummy-rollcage-client {}
             wrapped-handler (middleware/wrap-rollbar dummy-ring-handler
@@ -20,7 +22,8 @@
                          (catch Exception e
                            e))]
             (is (= result error))
-            (is (= [[dummy-rollcage-client error {:uri "/"}]]
+            (is (= [[dummy-rollcage-client error {:url "/search" :params {:http-method :get
+                                                                          :query-string "q=clojure"}}]]
                    (->> rollcage/error
                         bond/calls
                         (map :args))))))))


### PR DESCRIPTION
As of version 1.0.131, the parameters of the request is not reported to Rollbar.

From [ring wiki](https://github.com/ring-clojure/ring/wiki/Parameters), base request parameters look like this:
```
{:http-method :get
 :uri "/search"
 :query-string "q=clojure"}
```

It would then make sense that those are to be reported to rollcage client like:
```
{:url "/search"
 :params {:http-method :get
          :query-string "q=clojure"}
```

Also ring's `wrap-parameters` middleware adds three keys to the map: `:query-params`, `:form-params` and `:params`. As a large number of people are using this middleware, it sounds reasonable to add those as arguments sent to Rollbar.