### PR TITLE
Fix url key mismatch in ring-middleware

### DIFF
--- a/src/circleci/rollcage/ring_middleware.clj
+++ b/src/circleci/rollcage/ring_middleware.clj
@@ -8,5 +8,5 @@
       (try
         (handler req)
         (catch Exception e
-          (rollcage/error rollcage-client e (select-keys req [:uri]))
+          (rollcage/error rollcage-client e {:url (:uri req)})
           (throw e))))))


### PR DESCRIPTION
rollcage client expects an `:url` key in optional argument, currently the ring handler is sending an `:uri` key.