### PR TITLE
Set the language type to Java

### DIFF
--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -173,7 +173,7 @@
                 send-item-http)
      :data {:environment (name environment)
             :platform    (name os)
-            :language    "Clojure"
+            :language    "java"
             :framework   "Ring"
             :notifier    {:name "Rollcage"}
             :server      {:host hostname


### PR DESCRIPTION
This will force Rollbar to render callstacks in the typical Java order.