### PR TITLE
Add missing level mapping for debug severity

### DIFF
--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -138,7 +138,8 @@
   {"critical" :fatal
    "error"    :error
    "warning"  :warn
-   "info"     :info})
+   "info"     :info
+   "debug"    :debug})
 
 (defn- send-item-null
   [^String endpoint ^Throwable exception {:keys [data] :as item}]
@@ -187,7 +188,7 @@
 
 (defn client
   "Create a client that can can be passed used to send notifications to Rollbar.
-  The following options can be set: 
+  The following options can be set:
 
   :os
   The name of the operating system running on the host. Defaults to the value


### PR DESCRIPTION
This PR adds a mapping for debug severity, which prevents an `IllegalArgumentException` from being thrown if the `circleci.rollcage.core/debug` function is called. This should resolve #31 .