### PR TITLE
Try to avoid JSON encoding exceptions

### DIFF
--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -2,11 +2,11 @@
   (:require
     [clojure.string :as string]
     [clojure.tools.logging :as logging]
-    [cheshire.core :as json]
     [schema.core :as s]
     [clj-http.client :refer (post)]
     [clj-stacktrace.core :refer (parse-trace-elem)]
-    [clj-stacktrace.repl :refer (method-str)])
+    [clj-stacktrace.repl :refer (method-str)]
+    [circleci.rollcage.json :as json])
   (:import
     [java.net InetAddress UnknownHostException]
     [java.util UUID]))
@@ -130,9 +130,6 @@
       (assoc-in [:data :custom]            custom)
       (assoc-in [:data :request :url]      url)))
 
-(defn- snake-case [kw]
-  (string/replace (name kw) "-" "_"))
-
 (def ^:private rollbar-to-logging
   "A look-up table to map from Rollbar severity levels to tools.logging levels"
   {"critical" :fatal
@@ -158,11 +155,11 @@
                exception
                "Sending exception to Rollbar")
   (let [result (post endpoint
-                     {:body (json/generate-string item {:key-fn snake-case})
+                     {:body (json/encode item)
                       :conn-timeout http-conn-timeout
                       :socket-timeout http-socket-timeout
                       :content-type :json})]
-    (json/parse-string (:body result) true)))
+    (json/decode (:body result))))
 
 (s/defn ^:private client* :- Client
   [access-token :- (s/maybe String)

--- a/src/circleci/rollcage/json.clj
+++ b/src/circleci/rollcage/json.clj
@@ -1,17 +1,44 @@
 (ns circleci.rollcage.json
   (:require
     [clojure.string :as string]
-    [cheshire.core :as json])
+    [clojure.walk :refer (postwalk)]
+    [cheshire.core :as json]
+    [cheshire.generate :as gen]
+    [cheshire.factory :as factory])
   (:import
-    [com.fasterxml.jackson.core JsonGenerationException]))
+   [java.io StringWriter
+            Writer]
+   [com.fasterxml.jackson.core JsonFactory
+                               JsonGenerator
+                               JsonGenerationException]))
 
-(defn- snake-case [kw]
+(defn snake-case
+  [kw]
   (string/replace (name kw) "-" "_"))
 
-(defn encode
+(defn backstop-encoder
+  "Stringify an item if it's not possible to encode it normally. This should not
+   be called for most encoding jobs, only when it would otherwise throw an
+   exception."
   [item]
-  (json/generate-string item {:key-fn snake-case}))
+  (let [jg (.createGenerator
+            ^JsonFactory (or factory/*json-factory* factory/json-factory)
+            ^Writer (StringWriter.))]
+    (try
+     (gen/generate jg item factory/default-date-format nil snake-case)
+     item
+     (catch JsonGenerationException _
+       (str item)))))
+
+(defn encode
+  "Convert an arbitrary object into a JSON string."
+  [item]
+  (try
+   (json/generate-string item {:key-fn snake-case})
+   (catch JsonGenerationException _
+     (json/generate-string (postwalk backstop-encoder item) {:key-fn snake-case}))))
 
 (defn decode
+  "Decode a JSON string into an object."
   [^String string]
   (json/parse-string string true))

--- a/src/circleci/rollcage/json.clj
+++ b/src/circleci/rollcage/json.clj
@@ -1,0 +1,17 @@
+(ns circleci.rollcage.json
+  (:require
+    [clojure.string :as string]
+    [cheshire.core :as json])
+  (:import
+    [com.fasterxml.jackson.core JsonGenerationException]))
+
+(defn- snake-case [kw]
+  (string/replace (name kw) "-" "_"))
+
+(defn encode
+  [item]
+  (json/generate-string item {:key-fn snake-case}))
+
+(defn decode
+  [^String string]
+  (json/parse-string string true))

--- a/test/circleci/rollcage/test_json.clj
+++ b/test/circleci/rollcage/test_json.clj
@@ -1,0 +1,37 @@
+(ns circleci.rollcage.test-json
+  (:require [clojure.test :refer (are deftest is)]
+            [bond.james :as bond]
+            [circleci.rollcage.json :as json]))
+
+(deftest encode-for-normal-things-works-without-calling-the-backstop
+  (bond/with-spy [json/backstop-encoder]
+    (are [input expected]
+         (= expected (json/encode input))
+
+         {} "{}"
+         {:foo :bar} "{\"foo\":\"bar\"}"
+         {:foo-bar :baz-quux} "{\"foo_bar\":\"baz-quux\"}")
+    (is (= 0 (count (bond/calls json/backstop-encoder))))))
+
+(deftest encoding-odd-objects-does-not-throw
+  (are [input expected]
+       (= expected (json/encode input))
+
+       {:class (type 42)}
+       "{\"class\":\"class java.lang.Long\"}"
+
+       {:ip (java.net.InetAddress/getLoopbackAddress)}
+       "{\"ip\":\"localhost/127.0.0.1\"}"
+
+       {:class (type 42)
+        :integer 42
+        :string "string"}
+       "{\"class\":\"class java.lang.Long\",\"integer\":42,\"string\":\"string\"}"))
+
+(deftest decoding-works-as-expected
+  (are [input expected]
+       (= expected (json/decode input))
+       
+       "" nil
+       "{}" {}
+       "{\"foo\":\"bar\"}" {:foo "bar"}))


### PR DESCRIPTION
Rollcage uses [cheshire](https://github.com/dakrone/cheshire) to encode its payload before sending to Rollbar. Cheshire throws exceptions if an item in the map is not encodable using its standard set of encoders.

This change detects when a `JsonGenerationException` would be thrown and pre-processes the input to avoid throwing the exception. The approach taken is conservative and avoids stomping on custom encoders added by any codebase using this library.