### PR TITLE
Merge all ex-data from the exception chain into `custom`.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,7 @@
             [lein-shell "0.5.0"]
             [lein-pprint "1.1.1"]
             [lein-test-out "0.3.1" :exclusions [org.clojure/clojure]]]
+  :global-vars {*warn-on-reflection* true}
   :profiles {:dev {:dependencies [[org.clojure/test.check "0.7.0"]
                                   [circleci/bond "0.2.9"]]}}
   :test-selectors {:all         (constantly true)

--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -6,7 +6,8 @@
     [clj-http.client :refer (post)]
     [clj-stacktrace.core :refer (parse-trace-elem)]
     [clj-stacktrace.repl :refer (method-str)]
-    [circleci.rollcage.json :as json])
+    [circleci.rollcage.json :as json]
+    [circleci.rollcage.throwables :as throwables])
   (:import
     [java.net InetAddress UnknownHostException]
     [java.util UUID]))
@@ -234,7 +235,7 @@
    (notify level client exception {}))
   ([^String level {:keys [result-fn  send-fn] :as client} ^Throwable exception {:keys [url params]}]
    (let [log-level (rollbar-to-logging level)
-         params (merge params (ex-data exception))
+         params (merge params (throwables/merged-ex-data exception))
          item (make-rollbar client level exception url params)
          result (try
                   (send-fn endpoint exception item)

--- a/src/circleci/rollcage/throwables.clj
+++ b/src/circleci/rollcage/throwables.clj
@@ -1,0 +1,12 @@
+(ns circleci.rollcage.throwables)
+
+(defn- cause-seq
+  [^Throwable t]
+  (take-while some?
+              (iterate (fn [^Throwable e]
+                         (and e
+                              (.getCause e))) t)))
+
+(defn merged-ex-data
+  [^Throwable ex]
+  (reduce merge {} (map ex-data (cause-seq ex))))

--- a/test/circleci/rollcage/test_core.clj
+++ b/test/circleci/rollcage/test_core.clj
@@ -203,5 +203,16 @@
         (is (true? skipped))
         (is (UUID/fromString uuid))))))
 
+(deftest it-reports-ex-data
+  (let [p (promise)
+        client (assoc (client/client "access-token" {})
+                 :send-fn (fn [_ _ item]
+                            (deliver p item)
+                            {:err 0}))
+        _ (client/critical client (ex-info "outer" {:foo 1} (ex-info "inner" {:bar 2})))
+        result (deref p 0 :failed)]
+    (is (not (= result :failed)))
+    (is (= {:foo 1 :bar 2} (get-in result [:data :custom])))))
+
 (comment
   (run-tests))

--- a/test/circleci/rollcage/test_throwables.clj
+++ b/test/circleci/rollcage/test_throwables.clj
@@ -1,0 +1,17 @@
+(ns circleci.rollcage.test-throwables
+  (:require [circleci.rollcage.throwables :as throwables]
+            [clojure.test :refer (deftest is testing)]))
+
+(deftest cause-seq-works
+  (let [a (ex-info "a" {:name "a"})
+        b (ex-info "b" {:name "b"
+                        :b-added "this"} a)
+        c (ex-info "c" {:name "c"
+                        :c-added "this"} b)]
+    (is (= [a] (#'throwables/cause-seq a)))
+    (is (= [c b a] (#'throwables/cause-seq c)))
+    (is (= {:name "a"} (throwables/merged-ex-data a)))
+    (is (= {:name "a"
+            :b-added "this"
+            :c-added "this"}
+           (throwables/merged-ex-data c)))))


### PR DESCRIPTION
When a chained exception is thrown, it is useful to have all ex-data
fields reported to Rollbar.