### PR TITLE
Propagate arglists to the core API functions

### DIFF
--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -348,20 +348,11 @@
 
 (defmacro deflevel
   [level]
-  (let [level-str (str level)
-        docstring (str "Notify Rollbar of an exception with level `"
-                       level-str
-                       "`.\n  See the [[notify]] function for more information")
-        arglists  '([client exception]
-                    [{:keys [result-fn
-                             send-fn
-                             block-fields] :as client}
-                     exception
-                     {:keys [url params]}])]
-    `(do (def ~level (partial notify ~level-str))
-         (alter-meta! (var ~level) merge {:arglists (quote ~arglists)
-                                          :doc      ~docstring})
-         (var ~level))))
+  `(def ~(with-meta level
+           {:arglists (quote (-> #'notify meta :arglists))
+            :doc (str "Notify Rollbar of an exception with level `" level "`.\n  "
+                      "See the [[notify]] function for more information")})
+     (partial notify ~(str level))))
 
 (deflevel critical)
 (deflevel error)

--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -346,27 +346,24 @@
         (report-uncaught-exception "critical" client ex thread)
         (handler thread ex))))))
 
-(def critical
-  "Notify Rollbar of an exception with level `critical`.
-  See the [[notify]] function for more information."
-  (partial notify "critical"))
+(defmacro deflevel
+  [level]
+  (let [level-str (str level)
+        docstring (str "Notify Rollbar of an exception with level `"
+                       level-str
+                       "`.\n  See the [[notify]] function for more information")]
+    `(do (def ~level (partial notify ~level-str))
+         (alter-meta! (var ~level) assoc :arglists '([~'client ~'exception]
+                                                     [{:keys [~'result-fn
+                                                              ~'send-fn
+                                                              ~'block-fields] :as ~'client}
+                                                      ~'exception
+                                                      {:keys [~'url ~'params]}]))
+         (alter-meta! (var ~level) assoc :doc ~docstring)
+         (var ~level))))
 
-(def error
-  "Notify Rollbar of an exception with level `error`.
-  See the [[notify]] function for more information."
-  (partial notify "error"))
-
-(def warning
-  "Notify Rollbar of an exception with level `warning`.
-  See the [[notify]] function for more information."
-  (partial notify "warning"))
-
-(def info
-  "Notify Rollbar of an exception with level `info`.
-  See the [[notify]] function for more information."
-  (partial notify "info"))
-
-(def debug
-  "Notify Rollbar of an exception with level `debug`.
-  See the [[notify]] function for more information."
-  (partial notify "debug"))
+(deflevel critical)
+(deflevel error)
+(deflevel warning)
+(deflevel info)
+(deflevel debug)

--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -81,7 +81,7 @@
   "Given a sequence of strings (the source code) and a 1-indexed line, return the
   data that Rollbar expects to be able to render the source code on the error page."
   [lines line]
-  (let [zline (dec line) ; line is 1-indexed, z-line is 0-indexed 
+  (let [zline (dec line) ; line is 1-indexed, z-line is 0-indexed
         first-line (max 0 (- zline 3))
         pre-count (min zline 3)]
     {:code (nth lines zline)
@@ -236,7 +236,7 @@
 (defn client
   "Create a client that can can be passed used to send notifications to Rollbar.
   The following options can be set:
-  
+
   - `:os` The name of the operating system running on the host. Defaults to the value
   of the `os.name` system property.
   - `:hostname` The hostname of the host. You can usually ommit this key, the
@@ -351,14 +351,15 @@
   (let [level-str (str level)
         docstring (str "Notify Rollbar of an exception with level `"
                        level-str
-                       "`.\n  See the [[notify]] function for more information")]
+                       "`.\n  See the [[notify]] function for more information")
+        arglists  '([client exception]
+                    [{:keys [result-fn
+                             send-fn
+                             block-fields] :as client}
+                     exception
+                     {:keys [url params]}])]
     `(do (def ~level (partial notify ~level-str))
-         (alter-meta! (var ~level) assoc :arglists '([~'client ~'exception]
-                                                     [{:keys [~'result-fn
-                                                              ~'send-fn
-                                                              ~'block-fields] :as ~'client}
-                                                      ~'exception
-                                                      {:keys [~'url ~'params]}]))
+         (alter-meta! (var ~level) assoc :arglists (quote ~arglists))
          (alter-meta! (var ~level) assoc :doc ~docstring)
          (var ~level))))
 

--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -359,8 +359,8 @@
                      exception
                      {:keys [url params]}])]
     `(do (def ~level (partial notify ~level-str))
-         (alter-meta! (var ~level) assoc :arglists (quote ~arglists))
-         (alter-meta! (var ~level) assoc :doc ~docstring)
+         (alter-meta! (var ~level) merge {:arglists (quote ~arglists)
+                                          :dosstring ~docstring})
          (var ~level))))
 
 (deflevel critical)

--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -360,7 +360,7 @@
                      {:keys [url params]}])]
     `(do (def ~level (partial notify ~level-str))
          (alter-meta! (var ~level) merge {:arglists (quote ~arglists)
-                                          :dosstring ~docstring})
+                                          :doc      ~docstring})
          (var ~level))))
 
 (deflevel critical)


### PR DESCRIPTION
The main entrypoints to `rollcage` (e.g. `circleci.rollcage.core/info`)
lack metadata on the expected arguments. This change ensures each
function exposes the correct documentation including arglist.

Implementation wise, some macro magic is used to avoid repeating the
arglist which is a prety verbose block due to the destructuring
portions of the functions signatures.

Here's one of the effects of this change:

```clojure
circleci.rollcage.core> (deflevel critical)
;; => #'circleci.rollcage.core/critical
circleci.rollcage.core> (doc critical)
-------------------------
circleci.rollcage.core/critical
([client exception] [{:as client, :keys [result-fn send-fn block-fields]} exception {:keys [url params]}])
  Notify Rollbar of an exception with level `critical`.
  See the [[notify]] function for more information
;; => nil
```