### PR TITLE
Reduce memory consumption under heavy usage.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,6 +18,7 @@
                  [clj-http "2.0.0"]
                  [prismatic/schema "1.1.9"]
                  [clj-stacktrace "0.2.8"]
+                 [org.clojure/core.memoize "1.0.236"]
                  [org.clojure/tools.logging "0.4.0"]]
   :plugins [[lein-cloverage "1.0.6"]
             [lein-shell "0.5.0"]

--- a/src/circleci/rollcage/core.clj
+++ b/src/circleci/rollcage/core.clj
@@ -1,5 +1,6 @@
 (ns circleci.rollcage.core
   (:require
+   [clojure.core.memoize :as memo]
    [clojure.string :as string]
    [clojure.tools.logging :as logging]
    [clojure.java.io :as io]
@@ -99,7 +100,7 @@
     (catch Exception _
       {})))
 
-(defn- rollbar-frame
+(defn- rollbar-frame*
   "Convert a clj-stacktrace stack frame element to the format that the Rollbar
   REST API expects."
   [{:keys [file line] :as frame}]
@@ -107,6 +108,9 @@
          {:filename file
           :lineno line
           :method (method-str frame)}))
+
+(def ^:private rollbar-frame
+  (memo/lu rollbar-frame* :lu/threshold 1000))
 
 (defn- drop-common-head
   "Return a vector containing a copy of ys with any common head with xs removed.


### PR DESCRIPTION
If we are reporting many similar exceptions we will call `circleci.rollcage.core/build-trace` many times for exceptions with
identical or very similar stack traces. By memoizing `circleci.rollcage.core/rollbar-frame` we can avoid some expensive
re-work on the most common stack frames and thereby reduce the memory consumption (and I/O profile) of this library.

Rough testing suggests that this change can yield a >20x reduction in memory consumption when many similar exceptions are thrown.