### PR TITLE
Sends all nested exception's ex-data grouped in sub levels

### DIFF
--- a/src/circleci/rollcage/throwables.clj
+++ b/src/circleci/rollcage/throwables.clj
@@ -1,6 +1,8 @@
 (ns circleci.rollcage.throwables
   {:no-doc true})
 
+(def default-exception-key "__exception")
+
 (defn- cause-seq
   [^Throwable t]
   (take-while some?
@@ -8,6 +10,40 @@
                          (and e
                               (.getCause e))) t)))
 
-(defn merged-ex-data
+(defn merge-ex-data
   [^Throwable ex]
   (reduce merge {} (map ex-data (cause-seq ex))))
+
+(defn enriched-ex-data
+  [exception-name-field ^Throwable ex]
+  (assoc (ex-data ex)
+         exception-name-field
+         (ex-message ex)))
+
+(defn index-ex-data
+  [exception-name-field ^Throwable ex]
+  (let [exes     (reverse (cause-seq ex))
+        quantity (count exes)]
+    (if (= 1 quantity)
+      (ex-data (first exes))
+      (let [indexes      (range 0 quantity)
+            rich-ex-data (map (partial enriched-ex-data exception-name-field)
+                              exes)]
+        (zipmap indexes rich-ex-data)))))
+
+(defn select-exception-key
+  [indexed-ex-data]
+  (let [ekey (if-not (boolean? indexed-ex-data)
+              (str indexed-ex-data)
+              default-exception-key)]
+    (if-not (seq ekey)
+      default-exception-key
+      ekey)))
+
+(defn merged-ex-data
+  [{:keys [indexed-ex-data] :as client}
+   ^Throwable ex]
+  (if-not indexed-ex-data
+    (merge-ex-data ex)
+    (index-ex-data (select-exception-key indexed-ex-data)
+                   ex)))

--- a/test/circleci/rollcage/test_throwables.clj
+++ b/test/circleci/rollcage/test_throwables.clj
@@ -1,6 +1,6 @@
 (ns circleci.rollcage.test-throwables
   (:require [circleci.rollcage.throwables :as throwables]
-            [clojure.test :refer (deftest is)]
+            [clojure.test :refer (deftest is are)]
             [speculative.instrument]))
 
 (deftest cause-seq-works
@@ -11,8 +11,49 @@
                         :c-added "this"} b)]
     (is (= [a] (#'throwables/cause-seq a)))
     (is (= [c b a] (#'throwables/cause-seq c)))
-    (is (= {:name "a"} (throwables/merged-ex-data a)))
+    (is (= {:name "a"} (throwables/merge-ex-data a)))
     (is (= {:name "a"
             :b-added "this"
             :c-added "this"}
-           (throwables/merged-ex-data c)))))
+           (throwables/merge-ex-data c)))))
+
+(deftest select-exception-key-works
+  (are [input expected] (= expected (throwables/select-exception-key input))
+    nil         throwables/default-exception-key
+    ""          throwables/default-exception-key
+    123         "123"
+    "some-key"  "some-key"
+    :some-key   ":some-key"
+    identity    (str identity)))
+
+(deftest merged-ex-data-works
+  (let [simple-error-data {:a 1 :b 2}
+        simple-error      (ex-info "An error" simple-error-data)
+        nested-error      (ex-info "outer" {:foo 2 :bar 3} (ex-info "inner" {:foo 1}))]
+    (are [args expected]  (= expected
+                             (apply throwables/merged-ex-data args))
+      [{} simple-error]
+      simple-error-data
+
+      [{} nested-error]
+      {:foo 1 :bar 3}
+
+      [{:indexed-ex-data false} nested-error]
+      {:foo 1 :bar 3}
+
+      [{:indexed-ex-data true} simple-error]
+      simple-error-data
+
+      [{:indexed-ex-data true} nested-error]
+      {0 {"__exception" "inner"
+          :foo          1}
+       1 {"__exception" "outer"
+          :foo          2
+          :bar          3}}
+
+      [{:indexed-ex-data "KEY"} nested-error]
+      {0 {"KEY" "inner"
+          :foo  1}
+       1 {"KEY" "outer"
+          :foo  2
+          :bar  3}})))


### PR DESCRIPTION
This PR enables the client's option `:indexed-ex-data` to be able to send all neted exception's `ex-data` grouped under an indexed level.

## Background

Currently Rollcage only uses one level for the exception `ex-data` called `custom`. Under that level, an `ex-data` key would become `custom.some_value`. However, when you send nested exceptions, you don't know which exception the key belongs to, and repeated keys are overwritten, preferring the deepest exception in the tree.

So, for an exception like this:

```clojure
(def e (ex-info "Third level error"                                                                                                           
                {:name "Third error" :age 50 :extra {:jwt "THIRD ERROR"}}                                                                     
                (ex-info "Second level error"                                                                                                 
                         {:name "Second error" :age 39 :extra {:jwt "SECOND ERROR"}}                                                          
                         (ex-info "First level error" {:name "First error" :age 20 :extra {:jwt "FIRST ERROR"}})))) 
```

you currently see something like this:

![Screenshot from 2022-01-18 16-08-25](https://user-images.githubusercontent.com/37460128/149965085-61ddb2ba-c2cc-4ead-8974-a1975fd853cd.png)

with this information:

![Screenshot from 2022-01-18 16-09-16](https://user-images.githubusercontent.com/37460128/149965101-e924747e-5e5b-491e-a12a-0f4b66da47bf.png)

## Proposal

This PR enables a client like `(rollcage/client token {:indexed-ex-data "__exception" :block-fields [:jwt]})` to have the following information in Rollbar:

![Screenshot from 2022-01-18 16-08-49](https://user-images.githubusercontent.com/37460128/149965134-c1acee66-3f08-45ae-bc1f-be252f16ad2b.png)

