### PR TITLE
Add context to deploy job for Clojars creds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ workflows:
     jobs:
       - test
       - deploy:
+          context: clojars-publish
           requires:
             - test
           filters:


### PR DESCRIPTION
This supplies the necessary credentials to push new versions to Clojars.