### PR TITLE
Remove obsolete lein-cloverage plugin & codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Rollcage
 [![Circle CI](https://circleci.com/gh/circleci/rollcage.svg?style=svg)](https://circleci.com/gh/circleci/rollcage)
 [![cljdoc](https://cljdoc.org/badge/circleci/rollcage)](https://cljdoc.org/d/circleci/rollcage/CURRENT)
-[![codecov.io](https://codecov.io/github/circleci/rollcage/coverage.svg?branch=master)](https://codecov.io/github/circleci/rollcage?branch=master)
+[![Clojars Project](https://img.shields.io/clojars/v/circleci/rollcage.svg)](https://clojars.org/circleci/rollcage)
+
 
 A Clojure client for [Rollbar](http://rollbar.com)
 

--- a/project.clj
+++ b/project.clj
@@ -20,8 +20,7 @@
                  [clj-stacktrace "0.2.8"]
                  [org.clojure/core.memoize "1.0.236"]
                  [org.clojure/tools.logging "0.5.0"]]
-  :plugins [[lein-cloverage "1.0.6"]
-            [lein-shell "0.5.0"]
+  :plugins [[lein-shell "0.5.0"]
             [lein-pprint "1.1.1"]
             [lein-test-out "0.3.1" :exclusions [org.clojure/clojure]]]
   :global-vars {*warn-on-reflection* true}


### PR DESCRIPTION
We removed these in https://github.com/circleci/rollcage/pull/61

Replace the Codecov badge with a Clojars one.